### PR TITLE
Paramètre de langue dans le CloudTM!

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -22,6 +22,7 @@ namespace Nutritia
         static public int APP_WIDTH = 650;
         static public int APP_HEIGHT = 550;
         public const int POOL_TIME = 300;
+        static public Langue LangueInstance = Langue.FrancaisCanada;
     }
 
 }

--- a/Logic/Model/Entities/Langue.cs
+++ b/Logic/Model/Entities/Langue.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Nutritia
+{
+    public class Langue
+    {
+        private Langue() { }
+        private Langue(string nom, string ietf)
+        {
+            IETF = ietf;
+            Nom = nom;
+        }
+
+        public string IETF { private set; get; }
+        public string Nom { private set; get; }
+
+
+        public static readonly Langue FrancaisCanada = new Langue("Français Canada", "fr-CA");
+        public static readonly Langue AnglaisUSA = new Langue("Anglais États-Unis", "en-US");
+
+        public static Langue LangueFromIETF(string ietf)
+        {
+            if (ietf == AnglaisUSA.IETF)
+                return AnglaisUSA;
+            else
+                return FrancaisCanada;
+        }
+    }
+}

--- a/Logic/Model/Entities/Membre.cs
+++ b/Logic/Model/Entities/Membre.cs
@@ -25,6 +25,7 @@ namespace Nutritia
         public bool EstAdministrateur { get; set; }
         public bool EstBanni { get; set; }
 		public DateTime DerniereMaj { get; set; }
+        public Langue LangueMembre { get; set; }
 		public int Age
         {
             get

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -45,7 +45,7 @@ namespace Nutritia
 
         public MainWindow()
         {
-            CultureManager.UICulture = new CultureInfo(Properties.Settings.Default.Langue);
+            CultureManager.UICulture = new CultureInfo(App.LangueInstance.IETF);
 
             InitializeComponent();
             ConfigurerTaille();

--- a/Nutritia.csproj
+++ b/Nutritia.csproj
@@ -88,6 +88,7 @@
     <Compile Include="Logic\Model\Args\RetrieveUniteMesureArgs.cs" />
     <Compile Include="Logic\Model\Entities\Aliment.cs" />
     <Compile Include="Logic\Model\Entities\Calculatrice.cs" />
+    <Compile Include="Logic\Model\Entities\Langue.cs" />
     <Compile Include="Logic\Model\Entities\Membre.cs" />
     <Compile Include="Logic\Model\Entities\Menu.cs" />
     <Compile Include="Logic\Model\Entities\ModePaiement.cs" />
@@ -1045,7 +1046,7 @@
   </ItemGroup>
   <ItemGroup>
     <Resource Include="UI\Images\moneyBag.png" />
-	<Resource Include="UI\Ressources\FichierAide.txt" />
+    <Resource Include="UI\Ressources\FichierAide.txt" />
     <Resource Include="LogoIcon.ico" />
     <Content Include="Toolkit\Infralution\Infralution.Localization.Wpf.dll" />
     <Content Include="Toolkit\Infralution\Infralution.Localization.Wpf.pdb" />

--- a/UI/Pages/MenuGeneral.xaml.cs
+++ b/UI/Pages/MenuGeneral.xaml.cs
@@ -89,15 +89,25 @@ namespace Nutritia.UI.Pages
 
         private ObservableCollection<Langue> mapLangue;
 
-        Langue francais = new Langue(Nutritia.UI.Ressources.Localisation.Pages.MenuGeneral.LangueFrancais, "fr");
-        Langue anglais = new Langue(Nutritia.UI.Ressources.Localisation.Pages.MenuGeneral.LangueAnglais, "en");
+        Langue francais = new Langue(Nutritia.UI.Ressources.Localisation.Pages.MenuGeneral.LangueFrancais, "fr-CA");
+        Langue anglais = new Langue(Nutritia.UI.Ressources.Localisation.Pages.MenuGeneral.LangueAnglais, "en-US");
 
         public MenuGeneral()
         {
             CultureManager.UICultureChanged += CultureManager_UICultureChanged;
 
             mapLangue = new ObservableCollection<Langue>();
-            string codeLangueActif = Properties.Settings.Default.Langue;
+            string codeLangueActif;
+
+            if (App.MembreCourant.IdMembre != null)
+            {
+                codeLangueActif = App.MembreCourant.LangueMembre.IETF;
+            }
+            else
+            {
+                codeLangueActif = App.LangueInstance.IETF;
+            }
+
 
             mapLangue.Add(francais);
             mapLangue.Add(anglais);
@@ -111,10 +121,18 @@ namespace Nutritia.UI.Pages
         private void Button_Click(object sender, RoutedEventArgs e)
         {
             Langue langue = mapLangue.FirstOrDefault(l => l.Actif == true);
-            Properties.Settings.Default.Langue = langue.CodeISO;
-            Properties.Settings.Default.Save();
-
-            CultureManager.UICulture = new CultureInfo(Properties.Settings.Default.Langue);
+            //Properties.Settings.Default.Langue = langue.CodeISO;
+            //Properties.Settings.Default.Save();
+            if (App.MembreCourant.IdMembre != null)
+            {
+                App.MembreCourant.LangueMembre = Nutritia.Langue.LangueFromIETF(langue.CodeISO);
+                new MySqlMembreService().Update(App.MembreCourant);
+            }
+            else
+            {
+                App.LangueInstance = Nutritia.Langue.LangueFromIETF(langue.CodeISO);
+            }
+            CultureManager.UICulture = new CultureInfo(langue.CodeISO);
         }
 
         private void CultureManager_UICultureChanged(object sender, EventArgs e)

--- a/UI/Views/FenetreConnexion.xaml.cs
+++ b/UI/Views/FenetreConnexion.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using Infralution.Localization.Wpf;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -56,7 +57,7 @@ namespace Nutritia.UI.Views
                 else
                 {
                     App.MembreCourant = membreValidation;
-					
+                    CultureManager.UICulture = new CultureInfo(App.MembreCourant.LangueMembre.IETF);
                     ServiceFactory.Instance.GetService<IApplicationService>().ChangerVue(new MenuPrincipalConnecte());
 
                 }   

--- a/UI/Views/FenetreCreationProfil.xaml.cs
+++ b/UI/Views/FenetreCreationProfil.xaml.cs
@@ -389,7 +389,7 @@ namespace Nutritia.UI.Views
             App.MembreCourant.Masse = double.Parse(Masse.SelectionBoxItem.ToString());
             App.MembreCourant.MotPasse = Mot_passe.Password;
             App.MembreCourant.DateNaissance = (DateTime)Date_naissance.SelectedDate;
-            App.MembreCourant.DerniereMaj = DateTime.Now;
+            App.MembreCourant.LangueMembre = App.LangueInstance;
 
             /*-----------------------------------Restrictions alimentaires-----------------------------------*/
             

--- a/UI/Views/FenetreMenuPrincipalConnecte.xaml.cs
+++ b/UI/Views/FenetreMenuPrincipalConnecte.xaml.cs
@@ -14,6 +14,7 @@ using System.Windows.Navigation;
 using System.Windows.Shapes;
 using Infralution.Localization.Wpf;
 using Nutritia.UI.Views;
+using System.Globalization;
 
 namespace Nutritia.UI.Views
 {
@@ -47,6 +48,7 @@ namespace Nutritia.UI.Views
         private void btnDeconnexion_Click(object sender, RoutedEventArgs e)
         {
             App.MembreCourant = new Membre();
+            CultureManager.UICulture = new CultureInfo(App.LangueInstance.IETF);
             ServiceFactory.Instance.GetService<IApplicationService>().ChangerVue(new MenuPrincipal());
        
         }


### PR DESCRIPTION
- Modification des requêtes de MySqlMembreService pour aller chercher le
  IETF dans la BD associé au compte(s).
- Rajout de la classe Langue qui mimic les données en BD.
- N'utilise plus les settings de langues de l'application qui était
  enregistré sur l'ordinateur.
- Deux "langues". Une pour l'instance actuelle de l'application, l'autre
  du membre.
- Une fois connecté, le paramètre de langue du membre override la langue
  de l'instance de l'application. Une déconnexion change la langue
  d'affichage à celle de l'instance.
- Un compte nouvellement créé utilise la langue d'affichage
  actuelle comme paramètre de langue associé au compte.
