### PR TITLE
Vérification BD avant switch de connexion

### DIFF
--- a/Logic/Services/MySql/MySqlMembreService.cs
+++ b/Logic/Services/MySql/MySqlMembreService.cs
@@ -51,7 +51,12 @@ namespace Nutritia
 
             try
             {
-                connexion = new MySqlConnexion();
+                if (!String.IsNullOrWhiteSpace(stringConnexion))
+                {
+                    connexion = new MySqlConnexion(stringConnexion);
+                }
+                else
+                    connexion = new MySqlConnexion();
                 string requete = "SELECT * FROM Membres";
 
                 DataSet dataSetMembres = connexion.Query(requete);
@@ -124,7 +129,13 @@ namespace Nutritia
 
             try
             {
-                connexion = new MySqlConnexion();
+                if (!String.IsNullOrWhiteSpace(stringConnexion))
+                {
+                    connexion = new MySqlConnexion(stringConnexion);
+                }
+                else
+                    connexion = new MySqlConnexion();
+
                 string requete = string.Format("SELECT * FROM Membres WHERE idMembre = {0}", args.IdMembre);
 
                 if (args.NomUtilisateur != null && args.NomUtilisateur != string.Empty)
@@ -210,7 +221,13 @@ namespace Nutritia
         {
             try
             {
-                connexion = new MySqlConnexion();
+                if (!String.IsNullOrWhiteSpace(stringConnexion))
+                {
+                    connexion = new MySqlConnexion(stringConnexion);
+                }
+                else
+                    connexion = new MySqlConnexion();
+
                 string requete = string.Format("INSERT INTO Membres (nom ,prenom, taille, masse, dateNaissance, nomUtilisateur, motPasse, idLangue) VALUES ('{0}', '{1}', {2}, {3}, '{4}', '{5}', '{6}', (SELECT idLangue FROM Langues WHERE IETF = '{7}'))", membre.Nom, membre.Prenom, membre.Taille, membre.Masse, membre.DateNaissance.ToString("yyyy-MM-dd"), membre.NomUtilisateur, membre.MotPasse, membre.LangueMembre.IETF);
                 connexion.Query(requete);
 
@@ -252,7 +269,13 @@ namespace Nutritia
         {
             try
             {
-                connexion = new MySqlConnexion();
+                if (!String.IsNullOrWhiteSpace(stringConnexion))
+                {
+                    connexion = new MySqlConnexion(stringConnexion);
+                }
+                else
+                    connexion = new MySqlConnexion();
+
                 string requete = string.Format("UPDATE Membres SET nom = '{0}' ,prenom = '{1}', taille = {2}, masse = {3}, dateNaissance = '{4}', nomUtilisateur = '{5}', motPasse = '{6}', estAdmin = {7}, estBanni = {8}, idLangue = (SELECT idLangue FROM Langues WHERE IETF = '{9}') WHERE idMembre = {10}", membre.Nom, membre.Prenom, membre.Taille, membre.Masse, membre.DateNaissance.ToString("yyyy-MM-dd"), membre.NomUtilisateur, membre.MotPasse, membre.EstAdministrateur, membre.EstBanni, membre.LangueMembre.IETF, membre.IdMembre);
 
                 connexion.Query(requete);
@@ -316,8 +339,8 @@ namespace Nutritia
                 EstAdministrateur = (bool)membre["estAdmin"],
                 EstBanni = (bool)membre["estBanni"],
                 DerniereMaj = (DateTime)membre["derniereMaj"]
-                
-		    };
+
+            };
 
         }
 
@@ -327,7 +350,13 @@ namespace Nutritia
 
             try
             {
-                connexion = new MySqlConnexion();
+                if (!String.IsNullOrWhiteSpace(stringConnexion))
+                {
+                    connexion = new MySqlConnexion(stringConnexion);
+                }
+                else
+                    connexion = new MySqlConnexion();
+
                 string requete = "SELECT * FROM Membres WHERE estAdmin = True";
 
                 DataSet dataSetMembres = connexion.Query(requete);
@@ -393,7 +422,13 @@ namespace Nutritia
             Langue langue;
             try
             {
-                connexion = new MySqlConnexion();
+                if (!String.IsNullOrWhiteSpace(stringConnexion))
+                {
+                    connexion = new MySqlConnexion(stringConnexion);
+                }
+                else
+                    connexion = new MySqlConnexion();
+
                 string requete = string.Format("SELECT IETF FROM Langues WHERE idLangue = {0}", id);
                 using (DataSet dataSetLangue = connexion.Query(requete))
                 {
@@ -415,7 +450,13 @@ namespace Nutritia
             DateTime time;
             try
             {
-                connexion = new MySqlConnexion();
+                if (!String.IsNullOrWhiteSpace(stringConnexion))
+                {
+                    connexion = new MySqlConnexion(stringConnexion);
+                }
+                else
+                    connexion = new MySqlConnexion();
+
                 string requete = "SELECT * FROM LastModifiedMember";
                 using (DataSet dataSetLastUpdatedTime = connexion.Query(requete))
                 {

--- a/UI/Pages/MenuConnexion.xaml.cs
+++ b/UI/Pages/MenuConnexion.xaml.cs
@@ -95,10 +95,13 @@ namespace Nutritia.UI.Pages
                 return;
             //Valide si le compte actuel existe sur la nouvelle session spécifié et s'il est admins.
             //Sinon l'utilisateur ce coupe la branche sous les pieds.
-            //if (!IsAdminOnNewConnexion(newSession.ToConnexionString()))
-            //{
-            //    return;
-            //}
+            if (!IsAdminOnNewConnexion(newSession.ToConnexionString()))
+            {
+                MessageBox.Show("Impossible de se connecter. Est-ce que votre compte existe sur la base de données et êtes vous administrateur?",
+                    "Erreur de connexion", 
+                    MessageBoxButton.OK, MessageBoxImage.Error);
+                return;
+            }
             SwitchActive(obsSessions.IndexOf(SessionActive), obsSessions.IndexOf(newSession));
             SessionActive = newSession;
 
@@ -107,7 +110,7 @@ namespace Nutritia.UI.Pages
 
             IApplicationService mainWindow = ServiceFactory.Instance.GetService<IApplicationService>();
             mainWindow.Configurer();
-            mainWindow.ChangerVue(new MenuAdministrateur());
+            mainWindow.ChangerVue(new MenuPrincipalConnecte());
         }
 
 
@@ -204,10 +207,14 @@ namespace Nutritia.UI.Pages
                 IMembreService serviceMembre = new MySqlMembreService(stringConnexion);
                 IList<Membre> adminsDansNouvelleSession = serviceMembre.RetrieveAdmins();
                 //Lance une exception si le Where ne retourne rien, l'exception est géré de toute façon.
-                Membre membreCorrespondant = adminsDansNouvelleSession.Where(membre => membre.NomUtilisateur == App.MembreCourant.NomUtilisateur).First();
-
+                Membre membreCorrespondant = adminsDansNouvelleSession.Where(membre => membre.NomUtilisateur == App.MembreCourant.NomUtilisateur && membre.MotPasse == App.MembreCourant.MotPasse).First();
+                //Redondant, car on retrieves les admins et si membreCorrespondant est null, la lambda lance une exception.
                 if (membreCorrespondant != null && membreCorrespondant.EstAdministrateur)
+                {
+                    //Mauvaise place pour le faire, mais au cas le compte à des info différentes:
+                    App.MembreCourant = membreCorrespondant;
                     return true;
+                }
                 else
                     return false;
             }


### PR DESCRIPTION
- Message d'erreur si la vérification échoue.
- Dois avoir le même compte (nom utilisateur et mot de passe) sur la BD
  que la nouvelle connexion devra utilisé.
- Dois aussi être admin étant donné que la fonctionnalité est limité pour
  admin seulement.
- Écrase le membre de l'instance actuelle de l'application au switchover,
  au cas où certaines informations soient différentes.
- Ammène au menu principal connecté.
